### PR TITLE
Add flag to `dune-release check` that attempts to discover and parse the change log

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,10 +2,11 @@
 
 ### Added
 
-- Add flag to `dune-release check` that attempts to discover and parse the
-  change log. (#458, @gridbugs)
-
 ### Changed
+
+- Running `dune-release check` now attempts to discover and parse the
+  change log, and a new flag `--skip-change-log` disables this behaviour.
+  (#458, @gridbugs)
 
 ### Deprecated
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ### Added
 
+- Add flag to `dune-release check` that attempts to discover and parse the
+  change log. (#458, @gridbugs)
+
 ### Changed
 
 ### Deprecated

--- a/bin/check.ml
+++ b/bin/check.ml
@@ -15,7 +15,7 @@ let clone_and_checkout_tag repo ~dir ~tag =
 let check (`Package_names pkg_names) (`Package_version version) (`Dist_tag tag)
     (`Keep_v keep_v) (`Build_dir build_dir) (`Skip_lint skip_lint)
     (`Skip_build skip_build) (`Skip_tests skip_tests)
-    (`Working_tree on_working_tree) =
+    (`Check_change_log check_change_log) (`Working_tree on_working_tree) =
   (let dir, clean_up =
      if on_working_tree then (OS.Dir.current (), fun _ -> ())
      else
@@ -46,7 +46,7 @@ let check (`Package_names pkg_names) (`Package_version version) (`Dist_tag tag)
    Config.keep_v ~keep_v >>= fun keep_v ->
    let check_result =
      Check.check_project ~pkg_names ?tag ?version ~keep_v ?build_dir ~skip_lint
-       ~skip_build ~skip_tests ~dir ()
+       ~skip_build ~skip_tests ~check_change_log ~dir ()
    in
    let () = clean_up dir in
    check_result)
@@ -80,7 +80,7 @@ let term =
   Term.(
     const check $ Cli.pkg_names $ Cli.pkg_version $ Cli.dist_tag $ Cli.keep_v
     $ Cli.build_dir $ Cli.skip_lint $ Cli.skip_build $ Cli.skip_tests
-    $ working_tree)
+    $ Cli.check_change_log $ working_tree)
 
 let info = Cmd.info "check" ~doc ~man
 let cmd = Cmd.v info term

--- a/bin/check.ml
+++ b/bin/check.ml
@@ -15,7 +15,7 @@ let clone_and_checkout_tag repo ~dir ~tag =
 let check (`Package_names pkg_names) (`Package_version version) (`Dist_tag tag)
     (`Keep_v keep_v) (`Build_dir build_dir) (`Skip_lint skip_lint)
     (`Skip_build skip_build) (`Skip_tests skip_tests)
-    (`Check_change_log check_change_log) (`Working_tree on_working_tree) =
+    (`Skip_change_log skip_change_log) (`Working_tree on_working_tree) =
   (let dir, clean_up =
      if on_working_tree then (OS.Dir.current (), fun _ -> ())
      else
@@ -46,7 +46,7 @@ let check (`Package_names pkg_names) (`Package_version version) (`Dist_tag tag)
    Config.keep_v ~keep_v >>= fun keep_v ->
    let check_result =
      Check.check_project ~pkg_names ?tag ?version ~keep_v ?build_dir ~skip_lint
-       ~skip_build ~skip_tests ~check_change_log ~dir ()
+       ~skip_build ~skip_tests ~skip_change_log ~dir ()
    in
    let () = clean_up dir in
    check_result)
@@ -80,7 +80,7 @@ let term =
   Term.(
     const check $ Cli.pkg_names $ Cli.pkg_version $ Cli.dist_tag $ Cli.keep_v
     $ Cli.build_dir $ Cli.skip_lint $ Cli.skip_build $ Cli.skip_tests
-    $ Cli.check_change_log $ working_tree)
+    $ Cli.skip_change_log $ working_tree)
 
 let info = Cmd.info "check" ~doc ~man
 let cmd = Cmd.v info term

--- a/bin/cli.ml
+++ b/bin/cli.ml
@@ -256,6 +256,12 @@ let skip_tests =
   in
   named (fun x -> `Skip_tests x) Arg.(value & flag & info [ "skip-tests" ] ~doc)
 
+let check_change_log =
+  let doc = "Check that the change log can be parsed" in
+  named
+    (fun x -> `Check_change_log x)
+    Arg.(value & flag & info [ "check-change-log" ] ~doc)
+
 let keep_build_dir =
   let doc =
     "Keep the distribution build directory after successful archival."

--- a/bin/cli.ml
+++ b/bin/cli.ml
@@ -256,11 +256,11 @@ let skip_tests =
   in
   named (fun x -> `Skip_tests x) Arg.(value & flag & info [ "skip-tests" ] ~doc)
 
-let check_change_log =
-  let doc = "Check that the change log can be parsed" in
+let skip_change_log =
+  let doc = "Do not check that the change log can be parsed" in
   named
-    (fun x -> `Check_change_log x)
-    Arg.(value & flag & info [ "check-change-log" ] ~doc)
+    (fun x -> `Skip_change_log x)
+    Arg.(value & flag & info [ "skip-change-log" ] ~doc)
 
 let keep_build_dir =
   let doc =

--- a/bin/cli.mli
+++ b/bin/cli.mli
@@ -105,8 +105,8 @@ val skip_build : [> `Skip_build of bool ] Term.t
 val skip_tests : [> `Skip_tests of bool ] Term.t
 (** a [--skip-test] option to skip checking the tests *)
 
-val check_change_log : [> `Check_change_log of bool ] Term.t
-(** a [--check-change-log] option to force validation of change-log *)
+val skip_change_log : [> `Skip_change_log of bool ] Term.t
+(** a [--skip-change-log] option to skip validation of change-log *)
 
 val keep_build_dir : [> `Keep_build_dir of bool ] Term.t
 (** a [--keep-build-dir] flag to keep the build directory used for the archive

--- a/bin/cli.mli
+++ b/bin/cli.mli
@@ -105,6 +105,9 @@ val skip_build : [> `Skip_build of bool ] Term.t
 val skip_tests : [> `Skip_tests of bool ] Term.t
 (** a [--skip-test] option to skip checking the tests *)
 
+val check_change_log : [> `Check_change_log of bool ] Term.t
+(** a [--check-change-log] option to force validation of change-log *)
+
 val keep_build_dir : [> `Keep_build_dir of bool ] Term.t
 (** a [--keep-build-dir] flag to keep the build directory used for the archive
     check. *)

--- a/lib/check.ml
+++ b/lib/check.ml
@@ -100,8 +100,7 @@ let check_project ~pkg_names ~skip_lint ~skip_build ~skip_tests ?tag ?version
       dune_project_check dir >>= fun dune_project_exit ->
       dune_checks ~dry_run:false ~skip_build ~skip_tests ~pkg_names dir
       >>= fun dune_exit ->
-      if skip_lint then Ok 0
-      else
-        Lint.lint_packages ~dry_run:false ~dir ~todo:Lint.all pkg pkg_names
-        >>| fun lint_exit ->
-        opam_file_exit + dune_project_exit + dune_exit + lint_exit
+      (if skip_lint then Ok 0
+      else Lint.lint_packages ~dry_run:false ~dir ~todo:Lint.all pkg pkg_names)
+      >>| fun lint_exit ->
+      opam_file_exit + dune_project_exit + dune_exit + lint_exit

--- a/lib/check.mli
+++ b/lib/check.mli
@@ -16,7 +16,7 @@ val check_project :
   skip_lint:bool ->
   skip_build:bool ->
   skip_tests:bool ->
-  check_change_log:bool ->
+  skip_change_log:bool ->
   ?tag:Vcs.Tag.t ->
   ?version:Version.t ->
   keep_v:bool ->

--- a/lib/check.mli
+++ b/lib/check.mli
@@ -16,6 +16,7 @@ val check_project :
   skip_lint:bool ->
   skip_build:bool ->
   skip_tests:bool ->
+  check_change_log:bool ->
   ?tag:Vcs.Tag.t ->
   ?version:Version.t ->
   keep_v:bool ->

--- a/tests/bin/check/run.t
+++ b/tests/bin/check/run.t
@@ -223,3 +223,47 @@ The [--working-tree] option used so far, makes `check` be run on the working tre
   Have you provided a github uri in the dev-repo field of your main opam file? If you don't use github, you can still use dune-release for everything but for publishing your release on the web. In that case, have a look at `dune-release delegate-info`.
   [FAIL] The dune project doesn't contain a name stanza. Please, add one.
   [2]
+
+Detect case where there is no changelog file present:
+  $ dune-release check --skip-lint --skip-build --skip-tests --working-tree --check-change-log
+  [-] Checking dune-release compatibility.
+  [ OK ] The dev-repo field of my_pkg.opam contains a github uri.
+  [ OK ] The dune project contains a name stanza.
+  dune-release: [ERROR] No change log specified in the package description.
+    Error while running `check`: No change log specified in the package description.
+  [3]
+
+Create a simple changelog file:
+  $ cat > ChangeLog <<EOF
+  > #ChangeLog
+  > 
+  > ##0.2.0
+  > - a feature
+  > 
+  > ##0.1.0
+  > - another feature
+  > EOF
+
+  $ dune-release check --skip-lint --skip-build --skip-tests --working-tree --check-change-log
+  [-] Checking dune-release compatibility.
+  [ OK ] The dev-repo field of my_pkg.opam contains a github uri.
+  [ OK ] The dune project contains a name stanza.
+
+Create an invalid changelog file (the title is at the same H level to the rest of the file):
+  $ cat > ChangeLog <<EOF
+  > ##ChangeLog
+  > 
+  > ##0.2.0
+  > - a feature
+  > 
+  > ##0.1.0
+  > - another feature
+  > EOF
+
+  $ dune-release check --skip-lint --skip-build --skip-tests --working-tree --check-change-log
+  [-] Checking dune-release compatibility.
+  [ OK ] The dev-repo field of my_pkg.opam contains a github uri.
+  [ OK ] The dune project contains a name stanza.
+  dune-release: [ERROR] ./ChangeLog: Could not parse change log.
+    Error while running `check`: ./ChangeLog: Could not parse change log.
+  [3]

--- a/tests/bin/check/run.t
+++ b/tests/bin/check/run.t
@@ -24,6 +24,31 @@ Make a minimal project set up
   > (lang dune 2.7)
   > (name my_pkg)
   > EOF
+
+Test that the lint check produces an error if the change log is missing:
+  $ dune-release check --skip-change-log --working-tree | make_dune_release_deterministic
+  [-] Checking dune-release compatibility.
+  [ OK ] The dev-repo field of my_pkg.opam contains a github uri.
+  [ OK ] The dune project contains a name stanza.
+  
+  [-] Building package in <test_directory>
+  [ OK ] package(s) build
+  
+  [-] Running package tests in <test_directory>
+  [ OK ] package(s) pass the tests
+  
+  [-] Performing lint for package my_pkg in <test_directory>
+  [FAIL] File README is missing.
+  [FAIL] File LICENSE is missing.
+  [FAIL] File CHANGES is missing.
+  [ OK ] File opam is present.
+  [ OK ] lint opam file my_pkg.opam.
+  [ OK ] opam field synopsis is present
+  [ OK ] opam fields homepage and dev-repo can be parsed by dune-release
+  [ OK ] Skipping doc field linting, no doc field found
+  [FAIL] lint of <project_dir> and package my_pkg failure: 3 errors.
+
+Add a change log:
   $ cat > ChangeLog <<EOF
   > #ChangeLog
   > 
@@ -33,7 +58,6 @@ Make a minimal project set up
   > ##0.1.0
   > - another feature
   > EOF
-
 
 If the condition described above is fulfilled, there are 5 checks to be performed
 

--- a/tests/bin/check/run.t
+++ b/tests/bin/check/run.t
@@ -139,6 +139,7 @@ If the main opam file doesn't contain a dev-repo field, the first check fails
   [FAIL] main package my_pkg.opam is not dune-release compatible. Github development repository URL could not be inferred from opam files.
   Have you provided a github uri in the dev-repo field of your main opam file? If you don't use github, you can still use dune-release for everything but for publishing your release on the web. In that case, have a look at `dune-release delegate-info`.
   [FAIL] The dune project doesn't contain a name stanza. Please, add one.
+  [2]
 
 Add an invalid dev-repo field to the opam file
 
@@ -154,6 +155,7 @@ The first check also fails, if the opam file does contain a dev-repo field, but 
   [FAIL] main package my_pkg.opam is not dune-release compatible. Github development repository URL could not be inferred from opam files.
   Have you provided a github uri in the dev-repo field of your main opam file? If you don't use github, you can still use dune-release for everything but for publishing your release on the web. In that case, have a look at `dune-release delegate-info`.
   [FAIL] The dune project doesn't contain a name stanza. Please, add one.
+  [2]
 
 Create a sub-opam file with a valid dev-repo field
 
@@ -169,6 +171,7 @@ The first check only depends on the main package; all subpackages are irrelevant
   [FAIL] main package my_pkg.opam is not dune-release compatible. Github development repository URL could not be inferred from opam files.
   Have you provided a github uri in the dev-repo field of your main opam file? If you don't use github, you can still use dune-release for everything but for publishing your release on the web. In that case, have a look at `dune-release delegate-info`.
   [FAIL] The dune project doesn't contain a name stanza. Please, add one.
+  [2]
 
 Add a name stanza to the dune-project
 
@@ -219,3 +222,4 @@ The [--working-tree] option used so far, makes `check` be run on the working tre
   [FAIL] main package my_pkg.opam is not dune-release compatible. Github development repository URL could not be inferred from opam files.
   Have you provided a github uri in the dev-repo field of your main opam file? If you don't use github, you can still use dune-release for everything but for publishing your release on the web. In that case, have a look at `dune-release delegate-info`.
   [FAIL] The dune project doesn't contain a name stanza. Please, add one.
+  [2]

--- a/tests/bin/check/run.t
+++ b/tests/bin/check/run.t
@@ -24,8 +24,18 @@ Make a minimal project set up
   > (lang dune 2.7)
   > (name my_pkg)
   > EOF
+  $ cat > ChangeLog <<EOF
+  > #ChangeLog
+  > 
+  > ##0.2.0
+  > - a feature
+  > 
+  > ##0.1.0
+  > - another feature
+  > EOF
 
-If the condition described above is fulfilled, there are 4 checks to be performed
+
+If the condition described above is fulfilled, there are 5 checks to be performed
 
   $ dune-release check --working-tree | make_dune_release_deterministic
   [-] Checking dune-release compatibility.
@@ -41,13 +51,16 @@ If the condition described above is fulfilled, there are 4 checks to be performe
   [-] Performing lint for package my_pkg in <test_directory>
   [FAIL] File README is missing.
   [FAIL] File LICENSE is missing.
-  [FAIL] File CHANGES is missing.
+  [ OK ] File CHANGES is present.
   [ OK ] File opam is present.
   [ OK ] lint opam file my_pkg.opam.
   [ OK ] opam field synopsis is present
   [ OK ] opam fields homepage and dev-repo can be parsed by dune-release
   [ OK ] Skipping doc field linting, no doc field found
-  [FAIL] lint of <project_dir> and package my_pkg failure: 3 errors.
+  [FAIL] lint of <project_dir> and package my_pkg failure: 2 errors.
+  
+  [-] Validating change log.
+  [ OK ] Change log is valid.
 
 Add another package
 
@@ -78,24 +91,27 @@ In multi package projects, the whole lint process (including the file lints, eve
   [-] Performing lint for package my_pkg in <test_directory>
   [FAIL] File README is missing.
   [FAIL] File LICENSE is missing.
-  [FAIL] File CHANGES is missing.
+  [ OK ] File CHANGES is present.
   [ OK ] File opam is present.
   [ OK ] lint opam file my_pkg.opam.
   [ OK ] opam field synopsis is present
   [ OK ] opam fields homepage and dev-repo can be parsed by dune-release
   [ OK ] Skipping doc field linting, no doc field found
-  [FAIL] lint of <project_dir> and package my_pkg failure: 3 errors.
+  [FAIL] lint of <project_dir> and package my_pkg failure: 2 errors.
   
   [-] Performing lint for package my_pkg-sub in <test_directory>
   [FAIL] File README is missing.
   [FAIL] File LICENSE is missing.
-  [FAIL] File CHANGES is missing.
+  [ OK ] File CHANGES is present.
   [ OK ] File opam is present.
   [ OK ] lint opam file my_pkg-sub.opam.
   [ OK ] opam field synopsis is present
   [ OK ] opam fields homepage and dev-repo can be parsed by dune-release
   [ OK ] Skipping doc field linting, no doc field found
-  [FAIL] lint of <project_dir> and package my_pkg-sub failure: 3 errors.
+  [FAIL] lint of <project_dir> and package my_pkg-sub failure: 2 errors.
+  
+  [-] Validating change log.
+  [ OK ] Change log is valid.
 
 In the same way in which the user can skip the lint check when releasing the tarball, they can also skip it here
 
@@ -109,6 +125,9 @@ In the same way in which the user can skip the lint check when releasing the tar
   
   [-] Running package tests in <test_directory>
   [ OK ] package(s) pass the tests
+  
+  [-] Validating change log.
+  [ OK ] Change log is valid.
 
 Same for skipping the tests
 
@@ -119,6 +138,9 @@ Same for skipping the tests
   
   [-] Building package in <test_directory>
   [ OK ] package(s) build
+  
+  [-] Validating change log.
+  [ OK ] Change log is valid.
 
 Same for skipping the build (which implies skipping the tests)
 
@@ -126,6 +148,22 @@ Same for skipping the build (which implies skipping the tests)
   [-] Checking dune-release compatibility.
   [ OK ] The dev-repo field of my_pkg.opam contains a github uri.
   [ OK ] The dune project contains a name stanza.
+  
+  [-] Validating change log.
+  [ OK ] Change log is valid.
+
+Same for skipping the change log validation
+
+  $ dune-release check --working-tree --skip-lint --skip-change-log
+  [-] Checking dune-release compatibility.
+  [ OK ] The dev-repo field of my_pkg.opam contains a github uri.
+  [ OK ] The dune project contains a name stanza.
+  
+  [-] Building package in $TESTCASE_ROOT
+  [ OK ] package(s) build
+  
+  [-] Running package tests in $TESTCASE_ROOT
+  [ OK ] package(s) pass the tests
 
 Create a project with an opam file without dev-repo field
 
@@ -139,6 +177,9 @@ If the main opam file doesn't contain a dev-repo field, the first check fails
   [FAIL] main package my_pkg.opam is not dune-release compatible. Github development repository URL could not be inferred from opam files.
   Have you provided a github uri in the dev-repo field of your main opam file? If you don't use github, you can still use dune-release for everything but for publishing your release on the web. In that case, have a look at `dune-release delegate-info`.
   [FAIL] The dune project doesn't contain a name stanza. Please, add one.
+  
+  [-] Validating change log.
+  [ OK ] Change log is valid.
   [2]
 
 Add an invalid dev-repo field to the opam file
@@ -155,6 +196,9 @@ The first check also fails, if the opam file does contain a dev-repo field, but 
   [FAIL] main package my_pkg.opam is not dune-release compatible. Github development repository URL could not be inferred from opam files.
   Have you provided a github uri in the dev-repo field of your main opam file? If you don't use github, you can still use dune-release for everything but for publishing your release on the web. In that case, have a look at `dune-release delegate-info`.
   [FAIL] The dune project doesn't contain a name stanza. Please, add one.
+  
+  [-] Validating change log.
+  [ OK ] Change log is valid.
   [2]
 
 Create a sub-opam file with a valid dev-repo field
@@ -171,6 +215,9 @@ The first check only depends on the main package; all subpackages are irrelevant
   [FAIL] main package my_pkg.opam is not dune-release compatible. Github development repository URL could not be inferred from opam files.
   Have you provided a github uri in the dev-repo field of your main opam file? If you don't use github, you can still use dune-release for everything but for publishing your release on the web. In that case, have a look at `dune-release delegate-info`.
   [FAIL] The dune project doesn't contain a name stanza. Please, add one.
+  
+  [-] Validating change log.
+  [ OK ] Change log is valid.
   [2]
 
 Add a name stanza to the dune-project
@@ -187,6 +234,9 @@ With that, also the second compatibility test passes.
   [-] Checking dune-release compatibility.
   [ OK ] The dev-repo field of my_pkg-ppx.opam contains a github uri.
   [ OK ] The dune project contains a name stanza.
+  
+  [-] Validating change log.
+  [ OK ] Change log is valid.
 
 Make a project which is dune-release compatible on the working tree,
 but not dune-release compatible on the last git tag.
@@ -213,6 +263,9 @@ The [--working-tree] option used so far, makes `check` be run on the working tre
   [-] Checking dune-release compatibility.
   [ OK ] The dev-repo field of my_pkg.opam contains a github uri.
   [ OK ] The dune project contains a name stanza.
+  
+  [-] Validating change log.
+  [ OK ] Change log is valid.
 
  By default, `check` runs on a tag - either the one provided by [--tag] or [--version],
  or the last tag on HEAD.
@@ -222,34 +275,13 @@ The [--working-tree] option used so far, makes `check` be run on the working tre
   [FAIL] main package my_pkg.opam is not dune-release compatible. Github development repository URL could not be inferred from opam files.
   Have you provided a github uri in the dev-repo field of your main opam file? If you don't use github, you can still use dune-release for everything but for publishing your release on the web. In that case, have a look at `dune-release delegate-info`.
   [FAIL] The dune project doesn't contain a name stanza. Please, add one.
+  
+  [-] Validating change log.
+  [ OK ] Change log is valid.
   [2]
 
-Detect case where there is no changelog file present:
-  $ dune-release check --skip-lint --skip-build --skip-tests --working-tree --check-change-log
-  [-] Checking dune-release compatibility.
-  [ OK ] The dev-repo field of my_pkg.opam contains a github uri.
-  [ OK ] The dune project contains a name stanza.
-  dune-release: [ERROR] No change log specified in the package description.
-    Error while running `check`: No change log specified in the package description.
-  [3]
+Create an invalid change log file (the title is at the same H level to the rest of the file):
 
-Create a simple changelog file:
-  $ cat > ChangeLog <<EOF
-  > #ChangeLog
-  > 
-  > ##0.2.0
-  > - a feature
-  > 
-  > ##0.1.0
-  > - another feature
-  > EOF
-
-  $ dune-release check --skip-lint --skip-build --skip-tests --working-tree --check-change-log
-  [-] Checking dune-release compatibility.
-  [ OK ] The dev-repo field of my_pkg.opam contains a github uri.
-  [ OK ] The dune project contains a name stanza.
-
-Create an invalid changelog file (the title is at the same H level to the rest of the file):
   $ cat > ChangeLog <<EOF
   > ##ChangeLog
   > 
@@ -260,10 +292,20 @@ Create an invalid changelog file (the title is at the same H level to the rest o
   > - another feature
   > EOF
 
-  $ dune-release check --skip-lint --skip-build --skip-tests --working-tree --check-change-log
+  $ dune-release check --skip-lint --skip-build --skip-tests --working-tree
   [-] Checking dune-release compatibility.
   [ OK ] The dev-repo field of my_pkg.opam contains a github uri.
   [ OK ] The dune project contains a name stanza.
+  
+  [-] Validating change log.
+  [FAIL] Change log is not valid.
   dune-release: [ERROR] ./ChangeLog: Could not parse change log.
     Error while running `check`: ./ChangeLog: Could not parse change log.
   [3]
+
+Skip the change log check while the change log file is invalid.
+
+  $ dune-release check --skip-lint --skip-build --skip-tests --working-tree --skip-change-log
+  [-] Checking dune-release compatibility.
+  [ OK ] The dev-repo field of my_pkg.opam contains a github uri.
+  [ OK ] The dune project contains a name stanza.


### PR DESCRIPTION
I found that a project where `dune-release check` succeeded didn't publish because its change log failed to parse, and iterating on debugging and fixing the change log was difficult with no simple way to exercise the change log parsing logic.