### PR TITLE
Treat '-' underlines as H1 for first heading

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@
 
 ### Changed
 
+- In markdown changelog files, treat underline made of '-' characters as a H1 heading
+  rather than H2 heading if it is the first heading in a file (#460, @gridbugs)
+
 ### Deprecated
 
 ### Fixed


### PR DESCRIPTION
In changelogs, people can accidentally use '-' instead of '=' for markdown titles. Currently if they do this the file fails to parse if they also use '##' headings for versions, because the parser assumes that version headings will have higher heading values than the file's title.