### PR TITLE
Use project name for PR title and branch

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,9 +4,11 @@
 
 ### Changed
 
-- Running `dune-release check` now attempts to discover and parse the
-  change log, and a new flag `--skip-change-log` disables this behaviour.
-  (#458, @gridbugs)
+- Running `dune-release check` now attempts to discover and parse the change
+  log, and a new flag `--skip-change-log` disables this behaviour. (#458,
+  @gridbugs)
+- List the main package and amount of subpackages when creating the PR to avoid
+  very long package lists in PRs (#465, @emillon)
 
 ### Deprecated
 

--- a/bin/opam.ml
+++ b/bin/opam.ml
@@ -101,12 +101,6 @@ let pkg ~dry_run ~distrib_uri pkg =
       m "Wrote opam package description %a" Text.Pp.path dest_opam_file);
   if not dry_run then warn_if_vcs_dirty () else Ok ()
 
-let rec pp_list pp ppf = function
-  | [] -> ()
-  | [ x ] -> pp ppf x
-  | [ x; y ] -> Fmt.pf ppf "%a and %a" pp x pp y
-  | h :: t -> Fmt.pf ppf "%a, %a" pp h (pp_list pp) t
-
 let rec list_map f = function
   | [] -> Ok []
   | h :: t ->
@@ -202,6 +196,7 @@ let submit ~token ~dry_run ~yes ~opam_repo local_repo remote_repo pkgs auto_open
   Pkg.tag pkg >>= fun tag ->
   Pkg.build_dir pkg >>= fun build_dir ->
   Pkg.name pkg >>= fun name ->
+  let project_name = Pkg.project_name pkg in
   (if draft then Ok ()
   else
     match Config.Draft_release.is_set ~dry_run ~build_dir ~name ~version with
@@ -212,10 +207,7 @@ let submit ~token ~dry_run ~yes ~opam_repo local_repo remote_repo pkgs auto_open
     | _ -> Ok ())
   >>= fun () ->
   list_map Pkg.name pkgs >>= fun names ->
-  let title =
-    strf "[new release] %a (%a)" (pp_list Fmt.string) names
-      Dune_release.Version.pp version
-  in
+  let title = Github.pr_title ~names ~version ~project_name in
   Pkg.publish_msg pkg >>= fun changes ->
   let gh_repo = Rresult.R.to_option (Pkg.infer_github_repo pkg) in
   let changes =
@@ -229,7 +221,7 @@ let submit ~token ~dry_run ~yes ~opam_repo local_repo remote_repo pkgs auto_open
       l "Preparing %a to %a" Text.Pp.maybe_draft (draft, "pull request")
         pp_opam_repo opam_repo);
   Opam.prepare ~dry_run ~msg ~local_repo ~remote_repo ~opam_repo ~version ~tag
-    names
+    ~project_name names
   >>= fun branch ->
   open_pr ~dry_run ~changes ~remote_repo ~fork_owner ~branch ~token ~title
     ~opam_repo ~auto_open ~yes ~draft pkg

--- a/bin/opam.ml
+++ b/bin/opam.ml
@@ -175,8 +175,8 @@ let parse_remote_repo remote_repo =
          or providing a valid Github repo URL via the --remote-repo option."
         remote_repo
 
-let submit ~token ~dry_run ~yes ~opam_repo local_repo remote_repo pkgs auto_open
-    ~draft =
+let submit ~token ~dry_run ~yes ~opam_repo ~pkgs_to_submit local_repo
+    remote_repo pkgs auto_open ~draft =
   List.fold_left
     (fun acc pkg ->
       get_pkg_dir pkg >>= fun pkg_dir ->
@@ -207,7 +207,7 @@ let submit ~token ~dry_run ~yes ~opam_repo local_repo remote_repo pkgs auto_open
     | _ -> Ok ())
   >>= fun () ->
   list_map Pkg.name pkgs >>= fun names ->
-  let title = Github.pr_title ~names ~version ~project_name in
+  let title = Github.pr_title ~names ~version ~project_name ~pkgs_to_submit in
   Pkg.publish_msg pkg >>= fun changes ->
   let gh_repo = Rresult.R.to_option (Pkg.infer_github_repo pkg) in
   let changes =
@@ -293,7 +293,8 @@ let submit ?local_repo:local ?remote_repo:remote ?opam_repo ?user ?token
   Config.auto_open ~no_auto_open >>= fun auto_open ->
   App_log.status (fun m ->
       m "Submitting %a" Fmt.(list ~sep:sp Text.Pp.name) pkg_names);
-  submit ~token ~dry_run ~yes ~opam_repo local remote pkgs auto_open ~draft
+  submit ~token ~dry_run ~yes ~opam_repo ~pkgs_to_submit:pkg_names local remote
+    pkgs auto_open ~draft
 
 let field ~pkgs ~field_name = field pkgs field_name
 

--- a/bin/opam.ml
+++ b/bin/opam.ml
@@ -191,7 +191,7 @@ let submit ~token ~dry_run ~yes ~opam_repo ~pkgs_to_submit local_repo
           Ok 1)
     (Ok 0) pkgs
   >>= fun _ ->
-  let pkg = List.hd pkgs in
+  let pkg = Pkg.main pkgs in
   Pkg.version pkg >>= fun version ->
   Pkg.tag pkg >>= fun tag ->
   Pkg.build_dir pkg >>= fun build_dir ->

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -466,6 +466,22 @@ let publish_distrib ~token ~dry_run ~msg ~archive ~yes ~draft p =
   else Config.Release_asset_name.unset ~dry_run ~build_dir ~name ~version)
   >>= fun () -> Ok url
 
+let rec pp_list pp ppf = function
+  | [] -> ()
+  | [ x ] -> pp ppf x
+  | [ x; y ] -> Fmt.pf ppf "%a and %a" pp x pp y
+  | h :: t -> Fmt.pf ppf "%a, %a" pp h (pp_list pp) t
+
+let pr_title ~names ~version ~project_name =
+  let number_of_pkgs = List.length names in
+  let pp_name ppf =
+    match project_name with
+    | Some project_name when number_of_pkgs > 1 ->
+        Format.fprintf ppf "%s (%d packages)" project_name number_of_pkgs
+    | _ -> pp_list Fmt.string ppf names
+  in
+  strf "[new release] %t (%a)" pp_name Version.pp version
+
 (*---------------------------------------------------------------------------
    Copyright (c) 2016 Daniel C. Bünzli
 

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -472,13 +472,14 @@ let rec pp_list pp ppf = function
   | [ x; y ] -> Fmt.pf ppf "%a and %a" pp x pp y
   | h :: t -> Fmt.pf ppf "%a, %a" pp h (pp_list pp) t
 
-let pr_title ~names ~version ~project_name =
+let pr_title ~names ~version ~project_name ~pkgs_to_submit =
   let number_of_pkgs = List.length names in
   let pp_name ppf =
-    match project_name with
-    | Some project_name when number_of_pkgs > 1 ->
+    match (pkgs_to_submit, project_name) with
+    | [], Some project_name when number_of_pkgs > 1 ->
         Format.fprintf ppf "%s (%d packages)" project_name number_of_pkgs
-    | _ -> pp_list Fmt.string ppf names
+    | [], _ -> pp_list Fmt.string ppf names
+    | pkgs_to_submit, _ -> pp_list Fmt.string ppf pkgs_to_submit
   in
   strf "[new release] %t (%a)" pp_name Version.pp version
 

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -67,6 +67,9 @@ val undraft_pr :
 (** [undraft_pr] updates an existing pull request to undraft it and returns the
     pull request URL. *)
 
+val pr_title :
+  names:string list -> version:Version.t -> project_name:string option -> string
+
 (*---------------------------------------------------------------------------
    Copyright (c) 2016 Daniel C. Bünzli
 

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -68,7 +68,11 @@ val undraft_pr :
     pull request URL. *)
 
 val pr_title :
-  names:string list -> version:Version.t -> project_name:string option -> string
+  names:string list ->
+  version:Version.t ->
+  project_name:string option ->
+  pkgs_to_submit:string list ->
+  string
 
 (*---------------------------------------------------------------------------
    Copyright (c) 2016 Daniel C. Bünzli

--- a/lib/opam.ml
+++ b/lib/opam.ml
@@ -79,7 +79,7 @@ let prepare_package ~build_dir ~dry_run ~version vcs name =
   Vcs.run_git_quiet vcs ~dry_run ~force:true Cmd.(v "add" % p dst)
 
 let prepare ~dry_run ?msg ~local_repo ~remote_repo ~opam_repo ~version ~tag
-    names =
+    ~project_name names =
   let msg =
     match msg with
     | None -> Ok Cmd.empty
@@ -102,7 +102,7 @@ let prepare ~dry_run ?msg ~local_repo ~remote_repo ~opam_repo ~version ~tag
     Printf.sprintf "https://github.com/%s/%s.git" user repo
   in
   let remote_branch = "master" in
-  let pkg = shortest names in
+  let pkg = match project_name with Some n -> n | None -> shortest names in
   let branch = Fmt.str "release-%s-%a" pkg Vcs.Tag.pp tag in
   let prepare_repo () =
     App_log.status (fun l ->

--- a/lib/opam.mli
+++ b/lib/opam.mli
@@ -31,6 +31,7 @@ val prepare :
   opam_repo:string * string ->
   version:Version.t ->
   tag:Vcs.Tag.t ->
+  project_name:string option ->
   string list ->
   (Vcs.commit_ish, R.msg) result
 (** [prepare ~local_repo ~version pkgs] adds the packages [pkg.version] to a new

--- a/lib/pkg.mli
+++ b/lib/pkg.mli
@@ -46,6 +46,9 @@ val with_name : t -> string -> t
 (** [with_name t n] is [r] such that like [name r] is [n] and [f r] is [f t]
     otherwise. *)
 
+val project_name : t -> string option
+(** [project_name p] is the name of the project as found in [dune-project]. *)
+
 val version : t -> (Version.t, R.msg) result
 (** [version p] is [p]'s version.*)
 

--- a/lib/pkg.mli
+++ b/lib/pkg.mli
@@ -33,11 +33,16 @@ val v :
   ?license:Fpath.t ->
   ?distrib_file:Fpath.t ->
   ?publish_msg:string ->
+  ?project_name:string option ->
   unit ->
   t
 
 val infer_pkg_names : Fpath.t -> string list -> (string list, R.msg) result
 (** Infer the package list. *)
+
+val main : t list -> t
+(** Infer which package is the main one in a nonempty list (the one with a name
+    equal to the project name) *)
 
 val name : t -> (string, R.msg) result
 (** [name p] is [p]'s name. *)

--- a/tests/lib/test_github.ml
+++ b/tests/lib/test_github.ml
@@ -19,4 +19,20 @@ let test_ssh_uri_from_http =
     check "git+https://github.com/user/repo.git" None;
   ]
 
-let suite = ("Github", test_ssh_uri_from_http)
+let test_pr_title =
+  let check test_name ~project_name ~names ~expected =
+    let version = Dune_release.Version.of_string "1.2.3" in
+    let got = Dune_release.Github.pr_title ~names ~version ~project_name in
+    let test_fun () = Alcotest.(check string) __LOC__ expected got in
+    (test_name, `Quick, test_fun)
+  in
+  [
+    check "No project name" ~project_name:None ~names:[ "a"; "b"; "c" ]
+      ~expected:"[new release] a, b and c (1.2.3)";
+    check "With project name" ~project_name:(Some "b") ~names:[ "a"; "b"; "c" ]
+      ~expected:"[new release] b (3 packages) (1.2.3)";
+    check "1 package with project name" ~project_name:(Some "a") ~names:[ "a" ]
+      ~expected:"[new release] a (1.2.3)";
+  ]
+
+let suite = ("Github", test_ssh_uri_from_http @ test_pr_title)

--- a/tests/lib/test_github.ml
+++ b/tests/lib/test_github.ml
@@ -20,19 +20,27 @@ let test_ssh_uri_from_http =
   ]
 
 let test_pr_title =
-  let check test_name ~project_name ~names ~expected =
+  let check test_name ~project_name ~names ?selected ~expected () =
     let version = Dune_release.Version.of_string "1.2.3" in
-    let got = Dune_release.Github.pr_title ~names ~version ~project_name in
+    let pkgs_to_submit =
+      match selected with None -> [] | Some selected -> selected
+    in
+    let got =
+      Dune_release.Github.pr_title ~names ~version ~project_name ~pkgs_to_submit
+    in
     let test_fun () = Alcotest.(check string) __LOC__ expected got in
     (test_name, `Quick, test_fun)
   in
   [
     check "No project name" ~project_name:None ~names:[ "a"; "b"; "c" ]
-      ~expected:"[new release] a, b and c (1.2.3)";
+      ~expected:"[new release] a, b and c (1.2.3)" ();
     check "With project name" ~project_name:(Some "b") ~names:[ "a"; "b"; "c" ]
-      ~expected:"[new release] b (3 packages) (1.2.3)";
+      ~expected:"[new release] b (3 packages) (1.2.3)" ();
     check "1 package with project name" ~project_name:(Some "a") ~names:[ "a" ]
-      ~expected:"[new release] a (1.2.3)";
+      ~expected:"[new release] a (1.2.3)" ();
+    check "Multiple packages, just some selected" ~project_name:(Some "a")
+      ~names:[ "a"; "b"; "c" ] ~selected:[ "a"; "b" ]
+      ~expected:"[new release] a and b (1.2.3)" ();
   ]
 
 let suite = ("Github", test_ssh_uri_from_http @ test_pr_title)

--- a/tests/lib/test_pkg.ml
+++ b/tests/lib/test_pkg.ml
@@ -131,6 +131,36 @@ let test_dune_project_name =
       ~expected:(Some "xyz");
   ]
 
+let test_main =
+  let pkg ~name ~project_name ~msg =
+    Pkg.v ~dry_run:true ~name ~project_name ~publish_msg:msg ()
+  in
+  let test ~name pkgs ~expected_msg =
+    ( Printf.sprintf "Pkg.main: %s" name,
+      `Quick,
+      fun () ->
+        let got = Pkg.main pkgs in
+        let got_msg = Pkg.publish_msg got |> Rresult.R.failwith_error_msg in
+        Alcotest.check Alcotest.string __LOC__ expected_msg got_msg )
+  in
+  [
+    test ~name:"single package"
+      [ pkg ~name:"a" ~project_name:(Some "a") ~msg:"message for a" ]
+      ~expected_msg:"message for a";
+    test ~name:"two packages with a name"
+      [
+        pkg ~name:"a" ~project_name:(Some "b") ~msg:"message for a";
+        pkg ~name:"b" ~project_name:(Some "b") ~msg:"message for b";
+      ]
+      ~expected_msg:"message for b";
+    test ~name:"two packages, no name"
+      [
+        pkg ~name:"a" ~project_name:None ~msg:"message for a";
+        pkg ~name:"b" ~project_name:None ~msg:"message for b";
+      ]
+      ~expected_msg:"message for a";
+  ]
+
 let suite =
   ( "Pkg",
     List.concat
@@ -139,4 +169,5 @@ let suite =
         test_prepare_opam_for_distrib;
         distrib_uri;
         test_dune_project_name;
+        test_main;
       ] )


### PR DESCRIPTION
If we're submitting a PR for several packages, this uses "project name (N packages)" as PR title, and the project name is used for the branch.
Previously the branch was taken from the shortest package name.
