### PR TITLE
Implement support for OPAM files in `opam/` folder

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 ### Added
 
 - Adopt the OCaml Code of Conduct (#473, @rikusilvola)
+- Added support for projects that have their OPAM files in the `opam/`
+  subdirectory. (#466, @Leonidas-from-XIV)
 
 ### Changed
 

--- a/dune-project
+++ b/dune-project
@@ -25,6 +25,11 @@ with [Dune](https://github.com/ocaml/dune) and hosted on
 [GitHub](https://github.com).")
  (depends
   (ocaml (>= 4.08.0))
+  ;; two dependencies on dune to work around
+  ;; https://github.com/ocaml/dune/issues/3431
+  dune
+  ;; the tests require dune 3.8
+  (dune (and (>= 3.8) :with-test))
   (curly (>= 0.3.0))
   (fmt (>= 0.8.7))
   (fpath (>= 0.7.3))

--- a/dune-release.opam
+++ b/dune-release.opam
@@ -18,8 +18,9 @@ license: "ISC"
 homepage: "https://github.com/tarides/dune-release"
 bug-reports: "https://github.com/tarides/dune-release/issues"
 depends: [
-  "dune" {>= "2.7"}
   "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "dune" {>= "3.8" & with-test}
   "curly" {>= "0.3.0"}
   "fmt" {>= "0.8.7"}
   "fpath" {>= "0.7.3"}

--- a/tests/bin/opam-file-locations/dune
+++ b/tests/bin/opam-file-locations/dune
@@ -1,0 +1,8 @@
+(env
+ (_
+  (binaries
+   (../helpers/make_dune_release_deterministic.exe as
+     make_dune_release_deterministic))))
+
+(cram
+ (deps %{bin:dune-release} %{bin:make_dune_release_deterministic}))

--- a/tests/bin/opam-file-locations/run.t
+++ b/tests/bin/opam-file-locations/run.t
@@ -1,0 +1,100 @@
+Set up a project with an `.opam` file in the toplevel folder:
+
+  $ cat > CHANGES.md << EOF
+  > ## 0.1.0
+  > 
+  > - Initial release
+  > 
+  > EOF
+  $ cat > dune-project << EOF
+  > (lang dune 3.8)
+  > (name myproject)
+  > EOF
+  $ cat > myproject.opam << EOF
+  > opam-version: "2.0"
+  > EOF
+  $ git init 2> /dev/null . > /dev/null
+  $ touch README LICENSE
+  $ cat > .gitignore << EOF
+  > _build
+  > .bin
+  > /dune
+  > run.t
+  > EOF
+  $ git add CHANGES.md README LICENSE *.opam dune-project .gitignore
+  $ git commit -m 'Initial commit' > /dev/null
+
+Tagging should work
+
+  $ dune-release tag -y
+  [-] Extracting tag from first entry in CHANGES.md
+  [-] Using tag "0.1.0"
+  [+] Tagged HEAD with version 0.1.0
+
+`dune-release distrib` should work.
+
+  $ dune-release distrib --skip-lint | make_dune_release_deterministic
+  [-] Building source archive
+  [+] Wrote archive _build/myproject-0.1.0.tbz
+  
+  [-] Building package in _build/myproject-0.1.0
+  [ OK ] package(s) build
+  
+  [-] Running package tests in _build/myproject-0.1.0
+  [ OK ] package(s) pass the tests
+  
+  [+] Distribution for myproject 0.1.0
+  [+] Commit <deterministic>
+  [+] Archive _build/myproject-0.1.0.tbz
+
+Now let's move the `.opam` file to the `opam/` subfolder. OPAM supports `.opam`
+files in the `opam/` subfolder, but for dune to pick it up we need to tell it
+to look in that folder.
+
+Importantly, dune requires the packages in the `opam/` folder to be declared in
+`dune-project` as `package`.
+
+  $ mkdir opam
+  $ git mv myproject.opam opam/
+  $ cat  > CHANGES.md << EOF
+  > ## 0.2.0
+  > 
+  > - Move opam file to opam folder
+  > 
+  > EOF
+  $ cat >> dune-project << EOF
+  > (package
+  >   (name myproject)
+  >   (allow_empty))
+  > (opam_file_location inside_opam_directory)
+  > EOF
+  $ git add opam/myproject.opam CHANGES.md dune-project
+  $ git commit -m 'Moved opam file' > /dev/null
+
+Now we should still be able to tag:
+
+  $ dune-release tag -y
+  [-] Extracting tag from first entry in CHANGES.md
+  [-] Using tag "0.2.0"
+  [+] Tagged HEAD with version 0.2.0
+
+And as well have a release tarball
+
+  $ dune-release distrib --skip-lint | make_dune_release_deterministic
+  [-] Building source archive
+  [+] Wrote archive _build/myproject-0.2.0.tbz
+  
+  [-] Building package in _build/myproject-0.2.0
+  [ OK ] package(s) build
+  
+  [-] Running package tests in _build/myproject-0.2.0
+  [ OK ] package(s) pass the tests
+  
+  [+] Distribution for myproject 0.2.0
+  [+] Commit <deterministic>
+  [+] Archive _build/myproject-0.2.0.tbz
+
+Which contains the `.opam` file in the right location:
+
+  $ tar tf _build/myproject-0.2.0.tbz | grep \\.opam
+  myproject-0.2.0/opam/myproject.opam

--- a/tests/bin/opam-file-locations/run.t
+++ b/tests/bin/opam-file-locations/run.t
@@ -54,22 +54,24 @@ to look in that folder.
 Importantly, dune requires the packages in the `opam/` folder to be declared in
 `dune-project` as `package`.
 
-  $ mkdir opam
-  $ git mv myproject.opam opam/
   $ cat  > CHANGES.md << EOF
   > ## 0.2.0
   > 
-  > - Move opam file to opam folder
+  > - Use dune to generate opam file in opam subfolder
   > 
   > EOF
   $ cat >> dune-project << EOF
   > (package
   >   (name myproject)
   >   (allow_empty))
+  > (generate_opam_files true)
   > (opam_file_location inside_opam_directory)
   > EOF
+  $ git rm myproject.opam
+  rm 'myproject.opam'
+  $ dune build opam/myproject.opam
   $ git add opam/myproject.opam CHANGES.md dune-project
-  $ git commit -m 'Moved opam file' > /dev/null
+  $ git commit -m 'Opam file in subfolder' > /dev/null
 
 Now we should still be able to tag:
 


### PR DESCRIPTION
This requires the as of now not yet released dune 3.8, hence a draft. CI will most likely fail the test.