### PR TITLE
Conflict with old version of `result`

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -40,4 +40,6 @@ with [Dune](https://github.com/ocaml/dune) and hosted on
   logs
   odoc
   (alcotest :with-test)
-  (yojson (>= 1.6))))
+  (yojson (>= 1.6)))
+ (conflicts
+   (result (< 1.5))))

--- a/dune-release.opam
+++ b/dune-release.opam
@@ -37,6 +37,9 @@ depends: [
   "alcotest" {with-test}
   "yojson" {>= "1.6"}
 ]
+conflicts: [
+  "result" {< "1.5"}
+]
 build: [
   ["dune" "subst"] {dev}
   [


### PR DESCRIPTION
Some packages pull in `result` as transitive dependency, resulting in `Result` being not the Stdlib one but one that does not feature `Result.is_ok` if the `result` package is too old.

Given we do not have a direct dependency this is added as a conflict, so if our transitive dependencies drop `result` this problem should go away without introducing spurious dependendencies.

`result.1.5` fixes the issue by passing through `Result` from `Stdlib` on OCaml 4.08+ (which is our minimal supported version).