### PR TITLE
opam: fix lower bounds

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -36,7 +36,7 @@ with [Dune](https://github.com/ocaml/dune) and hosted on
   (opam-format (>= 2.1.0))
   (opam-state (>= 2.1.0))
   (opam-core (>= 2.1.0))
-  rresult
+  (rresult (>= 0.6.0))
   logs
   odoc
   (alcotest :with-test)

--- a/dune-project
+++ b/dune-project
@@ -42,4 +42,5 @@ with [Dune](https://github.com/ocaml/dune) and hosted on
   (alcotest :with-test)
   (yojson (>= 1.6)))
  (conflicts
-   (result (< 1.5))))
+   (result (< 1.5))
+   (dune (= 2.7.0))))

--- a/dune-release.opam
+++ b/dune-release.opam
@@ -31,7 +31,7 @@ depends: [
   "opam-format" {>= "2.1.0"}
   "opam-state" {>= "2.1.0"}
   "opam-core" {>= "2.1.0"}
-  "rresult"
+  "rresult" {>= "0.6.0"}
   "logs"
   "odoc"
   "alcotest" {with-test}

--- a/dune-release.opam
+++ b/dune-release.opam
@@ -39,6 +39,7 @@ depends: [
 ]
 conflicts: [
   "result" {< "1.5"}
+  "dune" {= "2.7.0"}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
We use `Rresult.R.failwith_error_msg` which has been added in 0.6.0.
