### PR TITLE
Fix the tests on macOS

### DIFF
--- a/tests/bin/opam-file-locations/run.t
+++ b/tests/bin/opam-file-locations/run.t
@@ -14,6 +14,8 @@ Set up a project with an `.opam` file in the toplevel folder:
   > opam-version: "2.0"
   > EOF
   $ git init 2> /dev/null . > /dev/null
+  $ git config user.name "dune-release-test"
+  $ git config user.email "pseudo@pseudo.invalid"
   $ touch README LICENSE
   $ cat > .gitignore << EOF
   > _build


### PR DESCRIPTION
Turns out only this test was failing because the other tests had this line already, presumably because someone ran the tests on macOS before.

Creating this as PR to make ocaml-ci run it as well and confirm it fixes the issue.