### PR TITLE
Allow to overwrite the dev-repo field when creating a GH tag/release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 - Add `dune-release delegate-info version` to show the current version as infered
   by the tool (#495, @samoht)
+- Add `--dev-repo` to `dune-release` and `dune-release publish` to overwrite
+  the `dev-repo` field specified in the opam file (#494, @samoht)
 
 ### Changed
 

--- a/bin/bistro.ml
+++ b/bin/bistro.ml
@@ -14,14 +14,14 @@ let bistro () (`Dry_run dry_run) (`Package_names pkg_names)
     (`Include_submodules include_submodules) (`Draft draft)
     (`Keep_build_dir keep_dir) (`Skip_lint skip_lint) (`Skip_build skip_build)
     (`Skip_tests skip_tests) (`Local_repo local_repo) (`Remote_repo remote_repo)
-    (`Opam_repo opam_repo) (`No_auto_open no_auto_open) =
+    (`Opam_repo opam_repo) (`No_auto_open no_auto_open) (`Dev_repo dev_repo) =
   Cli.handle_error
     ( Dune_release.Config.token ~token ~dry_run () >>= fun token ->
       let token = Dune_release.Config.Cli.make token in
       Distrib.distrib ~dry_run ~pkg_names ~version ~tag ~keep_v ~keep_dir
         ~skip_lint ~skip_build ~skip_tests ~include_submodules ()
       >! fun () ->
-      Publish.publish ~token ~pkg_names ~version ~tag ~keep_v ~dry_run
+      Publish.publish ~token ~pkg_names ~version ~tag ~keep_v ~dry_run ?dev_repo
         ~publish_artefacts:[] ~yes:false ~draft ()
       >! fun () ->
       Opam.get_pkgs ~dry_run ~keep_v ~tag ~pkg_names ~version () >>= fun pkgs ->
@@ -55,7 +55,8 @@ let term =
     const bistro $ Cli.setup $ Cli.dry_run $ Cli.pkg_names $ Cli.pkg_version
     $ Cli.dist_tag $ Cli.keep_v $ Cli.token $ Cli.include_submodules $ Cli.draft
     $ Cli.keep_build_dir $ Cli.skip_lint $ Cli.skip_build $ Cli.skip_tests
-    $ Cli.local_repo $ Cli.remote_repo $ Cli.opam_repo $ Cli.no_auto_open)
+    $ Cli.local_repo $ Cli.remote_repo $ Cli.opam_repo $ Cli.no_auto_open
+    $ Cli.dev_repo)
 
 let info = Cmd.info "bistro" ~doc ~sdocs ~exits ~man ~man_xrefs
 let cmd = Cmd.v info term

--- a/bin/cli.ml
+++ b/bin/cli.ml
@@ -227,6 +227,15 @@ let remote_repo =
   in
   named (fun x -> `Remote_repo x) (config_opt arg)
 
+let dev_repo =
+  let doc = "Location of the dev repo of the current package" in
+  let env = Cmd.Env.info "DUNE_RELEASE_DEV_REPO" in
+  let arg =
+    Arg.(
+      value & opt (some string) None & info ~env [ "dev-repo" ] ~doc ~docv:"URI")
+  in
+  named (fun x -> `Dev_repo x) arg
+
 let opam_repo =
   let doc =
     "The Github opam-repository to which packages should be released. Use this \

--- a/bin/cli.mli
+++ b/bin/cli.mli
@@ -87,13 +87,17 @@ val local_repo :
 (** A [--local-repo] option to define the location of the local fork of
     opam-repository. *)
 
+val dev_repo : [ `Dev_repo of string option ] Term.t
+(** A [--dev-repo] option to define the Github opam-repository to which packages
+    should be released. *)
+
 val remote_repo :
   [ `Remote_repo of string Dune_release.Config.Cli.t option ] Term.t
 (** A [--remote-repo] option to define the location of the remote fork of
     opam-repository. *)
 
 val opam_repo : [ `Opam_repo of (string * string) option ] Term.t
-(** A [--opam_repo] option to define the Github opam-repository to which
+(** A [--opam-repo] option to define the Github opam-repository to which
     packages should be released. *)
 
 val skip_lint : [> `Skip_lint of bool ] Term.t

--- a/bin/publish.mli
+++ b/bin/publish.mli
@@ -13,6 +13,7 @@ val publish :
   ?distrib_file:Fpath.t ->
   ?publish_msg:string ->
   ?token:string Dune_release.Config.Cli.t ->
+  ?dev_repo:string ->
   pkg_names:string list ->
   version:Dune_release.Version.t option ->
   tag:Dune_release.Vcs.Tag.t option ->

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -17,6 +17,7 @@ end
 
 val publish_distrib :
   token:string ->
+  ?dev_repo:string ->
   dry_run:bool ->
   msg:string ->
   archive:Fpath.t ->


### PR DESCRIPTION
This is useful for private projects where it's (sometimes) unclear what's the dev-repo field should look like (and sometimes `dune` will not generate the right one)