### PR TITLE
Fix publish help - no longer publish the doc

### DIFF
--- a/bin/publish.ml
+++ b/bin/publish.ml
@@ -39,7 +39,7 @@ let publish_cli () (`Build_dir build_dir) (`Package_version version)
 
 open Cmdliner
 
-let doc = "Publish package distribution archives and/or documentation."
+let doc = "Publish package distribution archives."
 let sdocs = Manpage.s_common_options
 let exits = Cli.exits
 let man_xrefs = [ `Main; `Cmd "distrib" ]


### PR DESCRIPTION
This is a small fix in the help of the `dune-release publish` command.

Recently the command was updated to remove the ability to publish the documentation, but the `--help` of the command still mentions about publishing the documentation. This PR removes that part.

I noticed this while upgrading to the new dune-release. Thanks!