### PR TITLE
Use newer GH runners for checks

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -8,6 +8,6 @@ on:
 jobs:
   Changelog-Entry-Check:
     name: Check Changelog Action
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: tarides/changelog-check-action@v1

--- a/.github/workflows/pr-number.yml
+++ b/.github/workflows/pr-number.yml
@@ -5,6 +5,6 @@ on: [pull_request_target]
 jobs:
   PR-Number-Update:
     name: Update PR number
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: tarides/pr-number-action@v1.1


### PR DESCRIPTION
It seems that Github [discontinued the Ubuntu 20.04 runner](https://github.com/actions/runner-images/issues/11101) so this PR updates it to a less old one.