### PR TITLE
Add a CLI flag for prerelease

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+### Added
+
+- Add support for marking a release as a prerelease. Closes  (#PR_NUMBER,
+  @Sudha247, closes #516)
+
 ## 2.2.0
 
 ### Breaking

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ### Added
 
-- Add support for marking a release as a prerelease. Closes  (#PR_NUMBER,
+- Add support for marking a release as a prerelease. Closes  (#517,
   @Sudha247, closes #516)
 
 ## 2.2.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,7 @@
 
 ### Added
 
-- Add support for marking a release as a prerelease. Closes  (#517,
-  @Sudha247, closes #516)
+- Add support for marking a release as a prerelease. (#517, @Sudha247)
 
 ## 2.2.0
 

--- a/bin/bistro.ml
+++ b/bin/bistro.ml
@@ -12,9 +12,10 @@ let ( >! ) x f = match x with Ok 0 -> f () | _ -> x
 let bistro () (`Dry_run dry_run) (`Package_names pkg_names)
     (`Package_version version) (`Dist_tag tag) (`Keep_v keep_v) (`Token token)
     (`Include_submodules include_submodules) (`Draft draft)
-    (`Keep_build_dir keep_dir) (`Skip_lint skip_lint) (`Skip_build skip_build)
-    (`Skip_tests skip_tests) (`Local_repo local_repo) (`Remote_repo remote_repo)
-    (`Opam_repo opam_repo) (`No_auto_open no_auto_open) (`Dev_repo dev_repo) =
+    (`Prerelease prerelease) (`Keep_build_dir keep_dir) (`Skip_lint skip_lint)
+    (`Skip_build skip_build) (`Skip_tests skip_tests) (`Local_repo local_repo)
+    (`Remote_repo remote_repo) (`Opam_repo opam_repo)
+    (`No_auto_open no_auto_open) (`Dev_repo dev_repo) =
   Cli.handle_error
     ( Dune_release.Config.token ~token ~dry_run () >>= fun token ->
       let token = Dune_release.Config.Cli.make token in
@@ -22,7 +23,7 @@ let bistro () (`Dry_run dry_run) (`Package_names pkg_names)
         ~skip_lint ~skip_build ~skip_tests ~include_submodules ()
       >! fun () ->
       Publish.publish ~token ~version ~tag ~keep_v ~dry_run ?dev_repo ~yes:false
-        ~draft ()
+        ~draft ~prerelease ()
       >! fun () ->
       Opam.get_pkgs ~dry_run ~keep_v ~tag ~pkg_names ~version () >>= fun pkgs ->
       Opam.pkg ~dry_run ~pkgs () >! fun () ->
@@ -54,9 +55,9 @@ let term =
   Term.(
     const bistro $ Cli.setup $ Cli.dry_run $ Cli.pkg_names $ Cli.pkg_version
     $ Cli.dist_tag $ Cli.keep_v $ Cli.token $ Cli.include_submodules $ Cli.draft
-    $ Cli.keep_build_dir $ Cli.skip_lint $ Cli.skip_build $ Cli.skip_tests
-    $ Cli.local_repo $ Cli.remote_repo $ Cli.opam_repo $ Cli.no_auto_open
-    $ Cli.dev_repo)
+    $ Cli.prerelease $ Cli.keep_build_dir $ Cli.skip_lint $ Cli.skip_build
+    $ Cli.skip_tests $ Cli.local_repo $ Cli.remote_repo $ Cli.opam_repo
+    $ Cli.no_auto_open $ Cli.dev_repo)
 
 let info = Cmd.info "bistro" ~doc ~sdocs ~exits ~man ~man_xrefs
 let cmd = Cmd.v info term

--- a/bin/cli.ml
+++ b/bin/cli.ml
@@ -186,7 +186,9 @@ let draft =
   named (fun x -> `Draft x) Arg.(value & flag & info [ "draft" ] ~doc)
 
 let prerelease =
-  let doc = "Produce a release that is marked as prerelease." in
+  let doc =
+    "Produce a release that is marked as prerelease on the Github release."
+  in
   named (fun x -> `Prerelease x) Arg.(value & flag & info [ "prerelease" ] ~doc)
 
 let yes =

--- a/bin/cli.ml
+++ b/bin/cli.ml
@@ -185,6 +185,10 @@ let draft =
   in
   named (fun x -> `Draft x) Arg.(value & flag & info [ "draft" ] ~doc)
 
+let prerelease =
+  let doc = "Produce a release that is marked as prerelease." in
+  named (fun x -> `Prerelease x) Arg.(value & flag & info [ "prerelease" ] ~doc)
+
 let yes =
   let doc = "Do not prompt for confirmation and keep going instead" in
   named (fun x -> `Yes x) Arg.(value & flag & info [ "y"; "yes" ] ~doc)

--- a/bin/cli.mli
+++ b/bin/cli.mli
@@ -73,6 +73,9 @@ val dry_run : [ `Dry_run of bool ] Term.t
 val draft : [ `Draft of bool ] Term.t
 (** A [--draft] option to produce a draft release. *)
 
+val prerelease : [ `Prerelease of bool ] Term.t
+(** A [--prerelease] option to mark a release as [prerelease]. *)
+
 val yes : [ `Yes of bool ] Term.t
 (** A [--yes] option to skip confirmation prompts. *)
 

--- a/bin/publish.ml
+++ b/bin/publish.ml
@@ -7,32 +7,35 @@
 open Bos_setup
 open Dune_release
 
-let publish_distrib ?token ~dry_run ~yes ~draft ?dev_repo pkg =
+let publish_distrib ?token ~dry_run ~yes ~draft ~prerelease ?dev_repo pkg =
   App_log.status (fun l -> l "Publishing distribution");
   Pkg.distrib_file ~dry_run pkg >>= fun archive ->
   Pkg.publish_msg pkg >>= fun msg ->
   App_log.status (fun l -> l "Publishing to github");
   Config.token ~token ~dry_run () >>= fun token ->
-  Github.publish_distrib ~token ~dry_run ~yes ~msg ~archive ~draft ?dev_repo pkg
+  Github.publish_distrib ~token ~dry_run ~yes ~msg ~archive ~draft ~prerelease
+    ?dev_repo pkg
   >>= fun url ->
   Pkg.archive_url_path pkg >>= fun url_file ->
   Sos.write_file ~dry_run url_file url >>= fun () -> Ok ()
 
 let publish ?build_dir ?opam ?change_log ?distrib_file ?publish_msg ?token
-    ?dev_repo ~version ~tag ~keep_v ~dry_run ~yes ~draft () =
+    ?dev_repo ~version ~tag ~keep_v ~dry_run ~yes ~draft ~prerelease () =
   Config.keep_v ~keep_v >>= fun keep_v ->
   let pkg =
     Pkg.v ~dry_run ?version ?tag ~keep_v ?build_dir ?opam ?change_log
       ?distrib_file ?publish_msg ()
   in
-  publish_distrib ?token ~dry_run ~yes ~draft ?dev_repo pkg >>= fun () -> Ok 0
+  publish_distrib ?token ~dry_run ~yes ~draft ~prerelease ?dev_repo pkg
+  >>= fun () -> Ok 0
 
 let publish_cli () (`Build_dir build_dir) (`Package_version version)
     (`Dist_tag tag) (`Keep_v keep_v) (`Dist_opam opam) (`Change_log change_log)
     (`Dist_file distrib_file) (`Publish_msg publish_msg) (`Dry_run dry_run)
-    (`Yes yes) (`Token token) (`Draft draft) (`Dev_repo dev_repo) =
+    (`Yes yes) (`Token token) (`Draft draft) (`Prerelease prerelease)
+    (`Dev_repo dev_repo) =
   publish ?build_dir ?opam ?change_log ?distrib_file ?publish_msg ?token
-    ~version ~tag ~keep_v ~dry_run ~yes ~draft ?dev_repo ()
+    ~version ~tag ~keep_v ~dry_run ~yes ~draft ~prerelease ?dev_repo ()
   |> Cli.handle_error
 
 (* Command line interface *)
@@ -60,7 +63,7 @@ let term =
     const publish_cli $ Cli.setup $ Cli.build_dir $ Cli.pkg_version
     $ Cli.dist_tag $ Cli.keep_v $ Cli.dist_opam $ Cli.change_log $ Cli.dist_file
     $ Cli.publish_msg $ Cli.dry_run $ Cli.yes $ Cli.token $ Cli.draft
-    $ Cli.dev_repo)
+    $ Cli.prerelease $ Cli.dev_repo)
 
 let info = Cmd.info "publish" ~doc ~sdocs ~exits ~man ~man_xrefs
 let cmd = Cmd.v info term

--- a/bin/publish.mli
+++ b/bin/publish.mli
@@ -20,6 +20,7 @@ val publish :
   dry_run:bool ->
   yes:bool ->
   draft:bool ->
+  prerelease:bool ->
   unit ->
   (int, Bos_setup.R.msg) result
 (** [publish ~build_dir ~opam ~change_log ~distrib_uri ~distrib_file

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -56,9 +56,11 @@ let run_with_auth ?(default_body = `Null) ~dry_run Curl.{ url; args; meth } =
         Json.from_string resp.body
     | Error e -> R.error_msgf "curl execution failed: %a" Curly.Error.pp e
 
-let curl_create_release ~token ~dry_run ~version ~tag ~draft msg user repo =
+let curl_create_release ~token ~dry_run ~version ~tag ~draft ~prerelease msg
+    user repo =
   let curl_t =
     Github_v3_api.Release.Request.create ~version ~tag ~msg ~user ~repo ~draft
+      ~prerelease
   in
   let curl_t = Github_v3_api.with_auth ~token curl_t in
   let default_body = `Assoc [ ("id", `Int D.release_id) ] in
@@ -286,7 +288,7 @@ let curl_get_release ~dry_run ~token ~tag ~user ~repo =
   run_with_auth ~dry_run curl_t >>= Github_v3_api.Release.Response.release_id
 
 let create_release ~dry_run ~yes ~dev_repo ~token ~msg ~tag ~version ~user ~repo
-    ~draft =
+    ~draft ~prerelease =
   match curl_get_release ~dry_run ~token ~tag ~user ~repo with
   | Error _ ->
       Prompt.(
@@ -300,6 +302,7 @@ let create_release ~dry_run ~yes ~dev_repo ~token ~msg ~tag ~version ~user ~repo
           l "Creating %a %a on %a via github's API" Text.Pp.maybe_draft
             (draft, "release") Text.Pp.version version Text.Pp.url dev_repo);
       curl_create_release ~token ~dry_run ~version ~tag msg user repo ~draft
+        ~prerelease
       >>= fun id ->
       App_log.success (fun l ->
           l "Successfully created %a with id %d" Text.Pp.maybe_draft
@@ -309,7 +312,8 @@ let create_release ~dry_run ~yes ~dev_repo ~token ~msg ~tag ~version ~user ~repo
       App_log.status (fun l -> l "Release with id %d already exists" id);
       Ok id
 
-let publish_distrib ~token ?dev_repo ~dry_run ~msg ~archive ~yes ~draft p =
+let publish_distrib ~token ?dev_repo ~dry_run ~msg ~archive ~yes ~draft
+    ~prerelease p =
   Pkg.infer_github_repo p >>= fun { owner; repo } ->
   Pkg.tag p >>= fun tag ->
   assert_tag_exists ~dry_run tag >>= fun () ->
@@ -324,7 +328,7 @@ let publish_distrib ~token ?dev_repo ~dry_run ~msg ~archive ~yes ~draft p =
   Pkg.version p >>= fun version ->
   push_tag ~dry_run ~yes ~dev_repo vcs tag >>= fun () ->
   create_release ~dry_run ~yes ~dev_repo ~token ~version ~msg ~tag ~user:owner
-    ~repo ~draft
+    ~repo ~draft ~prerelease
   >>= fun id ->
   (if draft then
      Config.Draft_release.set ~dry_run ~build_dir ~name ~version

--- a/lib/github.mli
+++ b/lib/github.mli
@@ -23,6 +23,7 @@ val publish_distrib :
   archive:Fpath.t ->
   yes:bool ->
   draft:bool ->
+  prerelease:bool ->
   Pkg.t ->
   (string, R.msg) Result.result
 (** Push the tag, create a Github release, upload the distribution archive and

--- a/lib/github_v3_api.ml
+++ b/lib/github_v3_api.ml
@@ -65,7 +65,7 @@ module Release = struct
       in
       Curl.{ url; meth = `GET; args }
 
-    let create ~version ~tag ~msg ~user ~repo ~draft =
+    let create ~version ~tag ~msg ~user ~repo ~draft ~prerelease =
       let json =
         Yojson.Basic.to_string
           (`Assoc
@@ -74,6 +74,7 @@ module Release = struct
                ("name", `String (Version.to_string version));
                ("body", `String msg);
                ("draft", `Bool draft);
+               ("prerelease", `Bool prerelease);
              ])
       in
       let url = strf "https://api.github.com/repos/%s/%s/releases" user repo in

--- a/lib/github_v3_api.mli
+++ b/lib/github_v3_api.mli
@@ -13,6 +13,7 @@ module Release : sig
       user:string ->
       repo:string ->
       draft:bool ->
+      prerelease:bool ->
       Curl.t
 
     val undraft : owner:string -> repo:string -> release_id:int -> Curl.t

--- a/tests/bin/invalid-version-number/run.t
+++ b/tests/bin/invalid-version-number/run.t
@@ -73,7 +73,7 @@ We do the whole dune-release process
   [-] Pushing tag 3.3.4_4.10preview1 to git@github.com:user/repo.git
        git --git-dir .git push --force git@github.com:user/repo.git   3.3.4_4.10preview1
   [-] Creating release 3.3.4~4.10preview1 on https://github.com/user/repo.git via github's API
-       {"tag_name":"3.3.4_4.10preview1","name":"3.3.4~4.10preview1","body":"CHANGES:\n\n- Some other feature\n","draft":false}
+       {"tag_name":"3.3.4_4.10preview1","name":"3.3.4~4.10preview1","body":"CHANGES:\n\n- Some other feature\n","draft":false,"prerelease":false}
   [-] Uploading _build/whatever-3.3.4~4.10preview1.tbz as a release asset for 3.3.4~4.10preview1 via github's API
        @_build/whatever-3.3.4~4.10preview1.tbz
   -: write _build/asset-3.3.4~4.10preview1.url

--- a/tests/bin/prerelease/dune
+++ b/tests/bin/prerelease/dune
@@ -1,0 +1,2 @@
+(cram
+ (deps %{bin:dune-release}))

--- a/tests/bin/prerelease/run.t
+++ b/tests/bin/prerelease/run.t
@@ -36,18 +36,14 @@ We need to set up a git project for dune-release to work properly
   $ git commit -m "Initial commit" > /dev/null
   $ dune-release tag -y > /dev/null
 
-We do the whole `dune-release` process but create a draft release on GitHub.
+We create a prerelease through the `dune-release` process.
 
 (1) `distrib` as normal
 
   $ dune-release distrib --dry-run > /dev/null
 
-(2) `publish` when asking for the release to be created as a draft should
-create a draft release and submit it as such to GitHub. It should also write a
-`draft_release` file for `undraft`.
+(2) `publish` when asking for the prerelease to be created should mark it as a
+prerelease and submit it as such to GitHub.
 
-  $ dune-release publish --dry-run --yes --draft | grep draft
-  [-] Creating draft release 0.1.0 on https://github.com/foo/whatever.git via github's API
-       {"tag_name":"0.1.0","name":"0.1.0","body":"CHANGES:\n\n- Some other feature\n","draft":true,"prerelease":false}
-  [+] Successfully created draft release with id 1
-  -: write _build/whatever-0.1.0.draft_release
+  $ dune-release publish --dry-run --yes --prerelease | grep prerelease
+       {"tag_name":"0.1.0","name":"0.1.0","body":"CHANGES:\n\n- Some other feature\n","draft":false,"prerelease":true}

--- a/tests/bin/prerelease/run.t
+++ b/tests/bin/prerelease/run.t
@@ -3,10 +3,6 @@ We need a basic opam project skeleton
   $ cat > CHANGES.md << EOF
   > ## 0.1.0
   > 
-  > - Some other feature
-  > 
-  > ## 0.0.0
-  > 
   > - Some feature
   > EOF
   $ cat > whatever.opam << EOF
@@ -46,4 +42,4 @@ We create a prerelease through the `dune-release` process.
 prerelease and submit it as such to GitHub.
 
   $ dune-release publish --dry-run --yes --prerelease | grep prerelease
-       {"tag_name":"0.1.0","name":"0.1.0","body":"CHANGES:\n\n- Some other feature\n","draft":false,"prerelease":true}
+       {"tag_name":"0.1.0","name":"0.1.0","body":"CHANGES:\n\n- Some feature\n","draft":false,"prerelease":true}

--- a/tests/lib/test_github_v3_api.ml
+++ b/tests/lib/test_github_v3_api.ml
@@ -1,25 +1,29 @@
 open Dune_release.Github_v3_api
 
 let test_create_release =
-  let make_test ~test_name ~version ~tag ~msg ~user ~repo ~draft ~expected =
+  let make_test ~test_name ~version ~tag ~msg ~user ~repo ~draft ~expected
+      ~prerelease =
     let version = Dune_release.Version.of_string version in
     let tag = Dune_release.Vcs.Tag.of_string tag in
     let test_fun () =
       let actual =
-        Release.Request.create ~version ~tag ~msg ~user ~repo ~draft
+        Release.Request.create ~version ~tag ~msg ~user ~repo ~draft ~prerelease
       in
       Alcotest.check Alcotest_ext.curl test_name expected actual
     in
     (test_name, `Quick, test_fun)
   in
+  let version = "1.1.0"
+  and tag = "1.1.0"
+  and msg = "this is a message"
+  and user = "you"
+  and repo = "some-repo"
+  and draft = false in
+
   [
-    (let version = "1.1.0"
-     and tag = "1.1.0"
-     and msg = "this is a message"
-     and user = "you"
-     and repo = "some-repo"
-     and draft = false in
-     make_test ~test_name:"simple" ~version ~tag ~msg ~user ~repo ~draft
+    (let prerelease = false in
+     make_test ~test_name:"simple-release" ~version ~tag ~msg ~user ~repo ~draft
+       ~prerelease
        ~expected:
          {
            url = "https://api.github.com/repos/you/some-repo/releases";
@@ -40,6 +44,34 @@ let test_create_release =
                             ("name", `String version);
                             ("body", `String msg);
                             ("draft", `Bool draft);
+                            ("prerelease", `Bool prerelease);
+                          ])));
+             ];
+         });
+    (let prerelease = true in
+     make_test ~test_name:"simple-prerelease" ~version ~tag ~msg ~user ~repo
+       ~draft ~prerelease
+       ~expected:
+         {
+           url = "https://api.github.com/repos/you/some-repo/releases";
+           meth = `POST;
+           args =
+             [
+               Location;
+               Silent;
+               Show_error;
+               Config `Stdin;
+               Dump_header `Ignore;
+               Data
+                 (`Data
+                    (Yojson.Basic.to_string
+                       (`Assoc
+                          [
+                            ("tag_name", `String tag);
+                            ("name", `String version);
+                            ("body", `String msg);
+                            ("draft", `Bool draft);
+                            ("prerelease", `Bool prerelease);
                           ])));
              ];
          });

--- a/tests/lib/test_github_v3_api.ml
+++ b/tests/lib/test_github_v3_api.ml
@@ -1,11 +1,42 @@
 open Dune_release.Github_v3_api
 
 let test_create_release =
-  let make_test ~test_name ~version ~tag ~msg ~user ~repo ~draft ~expected
-      ~prerelease =
-    let version = Dune_release.Version.of_string version in
-    let tag = Dune_release.Vcs.Tag.of_string tag in
+  let version = "1.1.0"
+  and tag = "1.1.0"
+  and msg = "this is a message"
+  and user = "you"
+  and repo = "some-repo"
+  and draft = false in
+  let make_test ~test_name ~prerelease =
+    let expected : Dune_release.Curl.t =
+      {
+        url = "https://api.github.com/repos/you/some-repo/releases";
+        meth = `POST;
+        args =
+          [
+            Location;
+            Silent;
+            Show_error;
+            Config `Stdin;
+            Dump_header `Ignore;
+            Data
+              (`Data
+                 (Yojson.Basic.to_string
+                    (`Assoc
+                       [
+                         ("tag_name", `String tag);
+                         ("name", `String version);
+                         ("body", `String msg);
+                         ("draft", `Bool draft);
+                         ("prerelease", `Bool prerelease);
+                       ])));
+          ];
+      }
+    in
     let test_fun () =
+      let version = Dune_release.Version.of_string version in
+      let tag = Dune_release.Vcs.Tag.of_string tag in
+
       let actual =
         Release.Request.create ~version ~tag ~msg ~user ~repo ~draft ~prerelease
       in
@@ -13,68 +44,9 @@ let test_create_release =
     in
     (test_name, `Quick, test_fun)
   in
-  let version = "1.1.0"
-  and tag = "1.1.0"
-  and msg = "this is a message"
-  and user = "you"
-  and repo = "some-repo"
-  and draft = false in
-
   [
-    (let prerelease = false in
-     make_test ~test_name:"simple-release" ~version ~tag ~msg ~user ~repo ~draft
-       ~prerelease
-       ~expected:
-         {
-           url = "https://api.github.com/repos/you/some-repo/releases";
-           meth = `POST;
-           args =
-             [
-               Location;
-               Silent;
-               Show_error;
-               Config `Stdin;
-               Dump_header `Ignore;
-               Data
-                 (`Data
-                    (Yojson.Basic.to_string
-                       (`Assoc
-                          [
-                            ("tag_name", `String tag);
-                            ("name", `String version);
-                            ("body", `String msg);
-                            ("draft", `Bool draft);
-                            ("prerelease", `Bool prerelease);
-                          ])));
-             ];
-         });
-    (let prerelease = true in
-     make_test ~test_name:"simple-prerelease" ~version ~tag ~msg ~user ~repo
-       ~draft ~prerelease
-       ~expected:
-         {
-           url = "https://api.github.com/repos/you/some-repo/releases";
-           meth = `POST;
-           args =
-             [
-               Location;
-               Silent;
-               Show_error;
-               Config `Stdin;
-               Dump_header `Ignore;
-               Data
-                 (`Data
-                    (Yojson.Basic.to_string
-                       (`Assoc
-                          [
-                            ("tag_name", `String tag);
-                            ("name", `String version);
-                            ("body", `String msg);
-                            ("draft", `Bool draft);
-                            ("prerelease", `Bool prerelease);
-                          ])));
-             ];
-         });
+    make_test ~test_name:"simple-release" ~prerelease:false;
+    make_test ~test_name:"simple-prerelease" ~prerelease:true;
   ]
 
 let test_upload_archive =


### PR DESCRIPTION
Fixes #516.

Adds a flag to mark a release as an aprerelease. Support for this already exists in the GitHub REST API. This patch exposes it to `dune-release` CLI.