### PR TITLE
Explicitely pass flag to decompress bzip2 archives in test

### DIFF
--- a/tests/bin/opam-file-locations/run.t
+++ b/tests/bin/opam-file-locations/run.t
@@ -100,5 +100,5 @@ And as well have a release tarball
 
 Which contains the `.opam` file in the right location:
 
-  $ tar tf _build/myproject-0.2.0.tbz | grep \\.opam
+  $ tar tjf _build/myproject-0.2.0.tbz | grep \\.opam
   myproject-0.2.0/opam/myproject.opam


### PR DESCRIPTION
While looking at the CI results of #517 the (optional) [OpenBSD tests are failing](https://github.com/tarides/dune-release/pull/517/checks?check_run_id=68503371124). But it looks that the only thing preventing them from passing is one single cram test.

`tar` on OpenBSD can decompress bzip2 but it does not do that automatically by default, unlike GNU tar or bsdtar.

However all tar implementations support the `j` flag so might as well use it in the test - we know it's always going to be a `bzip2` compressed file, so the autodetection is not necessary.

This should fix tests on OpenBSD while keeping it working just fine on all other platforms too.